### PR TITLE
Update client installation instruction & credentials management

### DIFF
--- a/solutions/exercise_2.3.2.1.py
+++ b/solutions/exercise_2.3.2.1.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ Poll the Fink servers only once at a time and plot alert """
 from fink_client.consumer import AlertConsumer
-import fink_client.fink_client_conf as fcc
+from fink_client.configuration import load_credentials
 
 from fink_client.visualisation import show_stamps
 from fink_client.visualisation import extract_field
@@ -115,19 +115,21 @@ def poll_single_alert() -> (str, dict):
         None if no alert has been returned from the servers.
     """
     # Load configuration parameters
-    myconfig = {
-        'username': fcc.username,
-        'bootstrap.servers': fcc.servers,
-        'group_id': fcc.group_id}
+    conf = load_credentials()
 
-    if fcc.password is not None:
-        myconfig['password'] = fcc.password
+    myconfig = {
+        "username": conf['username'],
+        'bootstrap.servers': conf['servers'],
+        'group_id': conf['group_id']}
+
+    if conf['password'] is not None:
+        myconfig['password'] = conf['password']
 
     # Instantiate a consumer
-    consumer = AlertConsumer(fcc.mytopics, myconfig, schema=fcc.schema)
+    consumer = AlertConsumer(conf['mytopics'], myconfig)
 
     # Poll the servers
-    topic, alert = consumer.poll(fcc.maxtimeout)
+    topic, alert = consumer.poll(conf['maxtimeout'])
 
     # Analyse output
     if topic is not None:
@@ -138,7 +140,9 @@ def poll_single_alert() -> (str, dict):
         ]
         print("{:<25}|{:<10}|{:<15}|{:<10}|{:<5}|".format(*row))
     else:
-        print('No alerts received in the last {} seconds'.format(fcc.maxtimeout))
+        print(
+            'No alerts received in the last {} seconds'.format(
+                conf['maxtimeout']))
 
     # Close the connection to the servers
     consumer.close()

--- a/solutions/exercise_2.3.2.2.py
+++ b/solutions/exercise_2.3.2.2.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ Poll the Fink servers only once at a time, plot alert, and save it """
 from fink_client.consumer import AlertConsumer
-import fink_client.fink_client_conf as fcc
+from fink_client.configuration import load_credentials
 
 from fink_client.visualisation import show_stamps
 from fink_client.visualisation import extract_field
@@ -121,19 +121,21 @@ def poll_single_alert(outdir: str) -> (str, dict):
         None if no alert has been returned from the servers.
     """
     # Load configuration parameters
-    myconfig = {
-        'username': fcc.username,
-        'bootstrap.servers': fcc.servers,
-        'group_id': fcc.group_id}
+    conf = load_credentials()
 
-    if fcc.password is not None:
-        myconfig['password'] = fcc.password
+    myconfig = {
+        "username": conf['username'],
+        'bootstrap.servers': conf['servers'],
+        'group_id': conf['group_id']}
+
+    if conf['password'] is not None:
+        myconfig['password'] = conf['password']
 
     # Instantiate a consumer
-    consumer = AlertConsumer(fcc.mytopics, myconfig, schema=fcc.schema)
+    consumer = AlertConsumer(conf['mytopics'], myconfig)
 
     # Poll the servers
-    topic, alert = consumer.poll_and_write(outdir, fcc.maxtimeout)
+    topic, alert = consumer.poll_and_write(outdir, conf['maxtimeout'])
 
     # Analyse output
     if topic is not None:
@@ -144,7 +146,9 @@ def poll_single_alert(outdir: str) -> (str, dict):
         ]
         print("{:<25}|{:<10}|{:<15}|{:<10}|{:<5}|".format(*row))
     else:
-        print('No alerts received in the last {} seconds'.format(fcc.maxtimeout))
+        print(
+            'No alerts received in the last {} seconds'.format(
+                conf['maxtimeout']))
 
     # Close the connection to the servers
     consumer.close()

--- a/solutions/exercise_2.3.2.3.py
+++ b/solutions/exercise_2.3.2.3.py
@@ -16,7 +16,7 @@
 reject alerts that are too close to a known Solar System object.
 """
 from fink_client.consumer import AlertConsumer
-import fink_client.fink_client_conf as fcc
+from fink_client.configuration import load_credentials
 
 from fink_client.visualisation import show_stamps
 from fink_client.visualisation import extract_field
@@ -149,19 +149,21 @@ def poll_single_alert(outdir: str) -> (str, dict):
         None if no alert has been returned from the servers.
     """
     # Load configuration parameters
-    myconfig = {
-        'username': fcc.username,
-        'bootstrap.servers': fcc.servers,
-        'group_id': fcc.group_id}
+    conf = load_credentials()
 
-    if fcc.password is not None:
-        myconfig['password'] = fcc.password
+    myconfig = {
+        "username": conf['username'],
+        'bootstrap.servers': conf['servers'],
+        'group_id': conf['group_id']}
+
+    if conf['password'] is not None:
+        myconfig['password'] = conf['password']
 
     # Instantiate a consumer
-    consumer = AlertConsumer(fcc.mytopics, myconfig, schema=fcc.schema)
+    consumer = AlertConsumer(conf['mytopics'], myconfig)
 
     # Poll the servers
-    topic, alert = consumer.poll_and_write(outdir, fcc.maxtimeout)
+    topic, alert = consumer.poll_and_write(outdir, conf['maxtimeout'])
 
     # Analyse output
     if topic is not None:
@@ -175,7 +177,9 @@ def poll_single_alert(outdir: str) -> (str, dict):
         ]
         print("{:<25}|{:<10}|{:<15}|{:<10}|{:<5}|{:<10}".format(*row))
     else:
-        print('No alerts received in the last {} seconds'.format(fcc.maxtimeout))
+        print(
+            'No alerts received in the last {} seconds'.format(
+                conf['maxtimeout']))
 
     # Close the connection to the servers
     consumer.close()

--- a/solutions/poll_single_alert.py
+++ b/solutions/poll_single_alert.py
@@ -14,25 +14,27 @@
 # limitations under the License.
 """ Poll the Fink servers only once at a time """
 from fink_client.consumer import AlertConsumer
-import fink_client.fink_client_conf as fcc
+from fink_client.configuration import load_credentials
 
 def poll_single_alert() -> None:
     """ Connect to and poll fink servers once.
     """
     # Load configuration parameters
-    myconfig = {
-        'username': fcc.username,
-        'bootstrap.servers': fcc.servers,
-        'group_id': fcc.group_id}
+    conf = load_credentials()
 
-    if fcc.password is not None:
-        myconfig['password'] = fcc.password
+    myconfig = {
+        "username": conf['username'],
+        'bootstrap.servers': conf['servers'],
+        'group_id': conf['group_id']}
+
+    if conf['password'] is not None:
+        myconfig['password'] = conf['password']
 
     # Instantiate a consumer
-    consumer = AlertConsumer(fcc.mytopics, myconfig, schema=fcc.schema)
+    consumer = AlertConsumer(conf['mytopics'], myconfig)
 
     # Poll the servers
-    topic, alert = consumer.poll(fcc.maxtimeout)
+    topic, alert = consumer.poll(conf['maxtimeout'])
 
     # Analyse output
     if topic is not None:
@@ -43,7 +45,11 @@ def poll_single_alert() -> None:
         ]
         print("{:<25}|{:<10}|{:<15}|{:<10}|{:<5}|".format(*row))
     else:
-        print('No alerts received in the last {} seconds'.format(fcc.maxtimeout))
+        print(
+            'No alerts received in the last {} seconds'.format(
+                conf['maxtimeout']
+            )
+        )
 
     # Close the connection to the servers
     consumer.close()

--- a/web/source/index.rst
+++ b/web/source/index.rst
@@ -24,36 +24,23 @@ and have similar structure to the expected one for LSST alerts.
 
 .. code-block:: bash
 
-  # Install fink-client somewhere on your computer
-  git clone https://github.com/astrolabsoftware/fink-client
-  cd fink-client
-  pip install --upgrade pip setuptools wheel
-  pip install -r requirements.txt
+  pip install fink-client
 
+Finally, in order to connect and poll alerts from Fink, you need to get your credentials:
 
-Then, assuming you are using bash shell, update your `~/.bash_profile` with the path to the library and binaries:
-
-.. code-block:: bash
-
-  # Add these lines at the end of your ~/.bash_profile
-  export FINK_CLIENT_HOME=${PWD}
-  export PYTHONPATH=${FINK_CLIENT_HOME}:$PYTHONPATH
-  export PATH=${FINK_CLIENT_HOME}/bin:$PATH
-
-
-Finally source the file to activate the changes, and check the correct installation:
-
-.. code-block:: bash
-
-  source ~/.bash_profile
-  python -c 'import fink_client; print(fink_client.__version__)'
-  # should print 0.2.0
+1. Subscribe to one or more Fink streams at https://forms.gle/2td4jysT4e9pkf889.
+2. After filling the form, we will send your credentials. Register them on your laptop by simply running:
+  ```
+  # You need fink-client installed - see above
+  fink_client_register -username <USERNAME> -group_id <GROUP_ID> ...
+  ```
 
 Tutorials
 --------------
 
-There will be 2h for tutorials. The first three are expected to be done
-within the 2h - and the others can be done at home later.
+The tutorials should take around 2h. The first three are the most important for users
+and they are expected to be doable within the 2h.
+The other tutorials expose more complex parts of the broker.
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
This PR brings two new updates:
- New installation instruction for the client. The way to install fink-client is as easy as `pip install fink-client`.
- New configuration & credentials management using `fink_client_register`.

Both changes would be effective after the merge of https://github.com/astrolabsoftware/fink-client/pull/55.